### PR TITLE
ci: 🎡 dangerfile.js の list_of_code (listOfCode()) の設定を修正した

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,21 +1,30 @@
 // cf. https://danger.systems/js/tutorials/node-app.html
+// cf. https://danger.systems/js/reference.html#GitDSL
+// cf. https://danger.systems/reference.html
 
-const changedNumberOfLines = danger.git.lines_of_code
-const LARGE_NUMBER_OF_CHANGED_LINES = 100
-const MINIMUM_NUMBER_OF_CHANGED_LINES = 10
-if (changedNumberOfLines > LARGE_NUMBER_OF_CHANGED_LINES) {
-  warn(
-    `👮‍♂ Pull Request が ${LARGE_NUMBER_OF_CHANGED_LINES} 行を超えており、大きめかもしれません。`
-  )
-}
-if (changedNumberOfLines < MINIMUM_NUMBER_OF_CHANGED_LINES) {
-  message(
-    `👍 Pull Request が ${MINIMUM_NUMBER_OF_CHANGED_LINES} 行未満であり、コンパクトです。`
-  )
-}
+;(async () => {
+  const changedNumberOfLines = await danger.git.linesOfCode()
+  const LARGE_NUMBER_OF_CHANGED_LINES = 100
+  const MINIMUM_NUMBER_OF_CHANGED_LINES = 10
+
+  if (changedNumberOfLines > LARGE_NUMBER_OF_CHANGED_LINES) {
+    warn(
+      `👮‍♂ Pull Request が ${LARGE_NUMBER_OF_CHANGED_LINES} 行を超えており、大きめかもしれません。`
+    )
+  }
+  if (changedNumberOfLines < MINIMUM_NUMBER_OF_CHANGED_LINES) {
+    message(
+      `👍 Pull Request が ${MINIMUM_NUMBER_OF_CHANGED_LINES} 行未満であり、コンパクトです。`
+    )
+  }
+
+  // markdown() も使える
+  message(`🖊 今回の Pull Request の変更行数は ${changedNumberOfLines} 行です。`)
+})()
 
 const isYarnLockChanged = danger.git.modified_files.includes('yarn.lock')
 const isPackageJsonChanged = danger.git.modified_files.includes('package.json')
+
 if (isYarnLockChanged && !isPackageJsonChanged) {
   warn(
     '👮‍♂ "yarn.lock" が変更されていますが、"package.json" が変更されていません。'


### PR DESCRIPTION
## 修正の過程
- `lines_of_code` が `undefined` になる
- Issue で見つける
  - 問題提起
    - https://github.com/danger/danger-js/issues/545
  - 機能追加 Pull Request
    - https://github.com/danger/danger-js/pull/834 
- 使ってみるがエラー
  - `danger.git.linesOfCode` という形で使っていた
  - 正しくは `danger.git.linesOfCode()` になる
- 行数が表示されると思ったら `Promise` で表示された
  - `async` ～ `await` に修正
- 期待どおりに表示された

## 修正の過程（画像）
[![Image from Gyazo](https://i.gyazo.com/4b84e027e96797f1030fb37fbea1a1e7.png)](https://gyazo.com/4b84e027e96797f1030fb37fbea1a1e7)
↓
[![Image from Gyazo](https://i.gyazo.com/57fd173f70dd554bcc6911478d2465ab.png)](https://gyazo.com/57fd173f70dd554bcc6911478d2465ab)
↓
[![Image from Gyazo](https://i.gyazo.com/329631390980e0489deaf855c39b8cac.png)](https://gyazo.com/329631390980e0489deaf855c39b8cac)
↓
[![Image from Gyazo](https://i.gyazo.com/f198736ddec484e0854155d0566d5a89.png)](https://gyazo.com/f198736ddec484e0854155d0566d5a89)