### PR TITLE
fix: 🐛 isolatedModules エラーを防ぐために "cypress/**" を exclude 対象とする

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
     "**/*.tsx"
   ],
   "exclude": [
+    "cypress/**",
     "node_modules"
   ]
 }


### PR DESCRIPTION
- [ts-jestでcannot be compiled under '--isolatedModules'と出た時の対処法](https://zenn.dev/ryo_kawamata/articles/0f63b7ffdaed97)