### PR TITLE
refactor: 💡 コンポーネントのディレクトリ・ファイル設計を見直した（第三弾）

### DIFF
--- a/components/events-in-event/index.tsx
+++ b/components/events-in-event/index.tsx
@@ -2,7 +2,7 @@ import type { NextPage } from 'next'
 import Link from 'next/link'
 import { useLocale } from '@/hooks/useLocale'
 
-const Kikaku: NextPage = () => {
+const EventsInEventIndex: NextPage = () => {
   const { locale } = useLocale()
 
   return (
@@ -94,4 +94,4 @@ const Kikaku: NextPage = () => {
   )
 }
 
-export default Kikaku
+export default EventsInEventIndex

--- a/pages/events-in-event.tsx
+++ b/pages/events-in-event.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import HumbergerNavigation from '@/components/humberger-menu/HumbergerNavigation'
 import NavBar from '@/components/common/NavBar'
 import SiteFooter from '@/components/common/SiteFooter'
-import Kikaku from '@/components/events-in-event/Kikaku'
+import EventsInEventIndex from '@/components/events-in-event/index'
 
 import { useLocale } from '@/hooks/useLocale'
 
@@ -32,7 +32,7 @@ const EventsInEvent: NextPage = () => {
           </ul>
         </div>
 
-        <Kikaku />
+        <EventsInEventIndex />
 
         <div className="divider" />
         <SiteFooter />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,7 +14,7 @@ import VoteExamples from '@/components/votes/VoteExamples'
 import Departments from '@/components/votes/Departments'
 import Dendouiri from '@/components/votes/Dendouiri'
 import Onegai from '@/components/votes/Onegai'
-import Kikaku from '@/components/events-in-event/Kikaku'
+import EventsInEventIndex from '@/components/events-in-event/index'
 
 import WhatIsGensosenkyo from '@/components/votes/WhatIsGensosenkyo'
 import IllustratedBy from '@/components/common/IllustratedBy'
@@ -129,7 +129,7 @@ const Home: NextPage = () => {
         <Onegai />
 
         <div className="divider" />
-        <Kikaku />
+        <EventsInEventIndex />
 
         <div className="divider" />
         <IllustratedBy />


### PR DESCRIPTION
- `Kikaku` という命名をやめる