### PR TITLE
feat: 🎸 i18n を正式に実装した（訳語はまだ）

### DIFF
--- a/i18n.json
+++ b/i18n.json
@@ -1,0 +1,7 @@
+{
+  "locales": ["ja", "en"],
+  "defaultLocale": "ja",
+  "pages": {
+    "*": ["common"]
+  }
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,12 +1,10 @@
 /** @type {import('next').NextConfig} */
-module.exports = {
+const nextTranslate = require('next-translate')
+
+module.exports = nextTranslate({
   reactStrictMode: true,
   experimental: {
     optimizeFonts: true,
     scrollRestoration: true,
   },
-  i18n: {
-    locales: ['ja', 'en'],
-    defaultLocale: 'ja',
-  },
-}
+})

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gridjs-react": "^5.0.2",
     "jest": "^28.1.1",
     "jest-environment-jsdom": "^28.1.1",
+    "next-translate": "^1.4.0",
     "npm-run-all": "^4.1.5",
     "postcss": "8.4.14",
     "prettier": "^2.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4480,6 +4480,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
+next-translate@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/next-translate/-/next-translate-1.4.0.tgz#8e423ea9010019ac9573cb6c88412273f8210f77"
+  integrity sha512-FWheoN83fWTTfZ2g+a77GBcXRDVfSDP45iA0+G5wRZYE3xPYMy/6X+1I5j+ouczoJ2JI54vH59W/veZ1tZDRGQ==
+
 next@12.1.6:
   version "12.1.6"
   resolved "https://registry.yarnpkg.com/next/-/next-12.1.6.tgz#eb205e64af1998651f96f9df44556d47d8bbc533"


### PR DESCRIPTION
close https://github.com/true-runes/suikoden-election-2022-frontend/issues/275

- feat: 🎸 $ yarn add --dev next-translate
- feat: 🎸 i18n の設定ファイルを追加した

使ったライブラリは `next-translate`
- https://github.com/vinissimus/next-translate

シンプルで良い。