### PR TITLE
Revert "ci: 🎡 setup-node のキャッシュを一時的に無効にする (#452)"

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -17,9 +17,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-          # FIXME: 不具合により一時的にキャッシュを無効化する
-          # https://github.com/actions/setup-node/issues/516#issuecomment-1153635273
-          # cache: yarn
+          cache: yarn
       - name: 日本語フォントのインストールを行う
         run: |
           sudo apt install -y fonts-migmix

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,9 +16,7 @@ jobs:
       uses: actions/setup-node@v3
       with:
         node-version: ${{ matrix.node-version }}
-        # FIXME: 不具合により一時的にキャッシュを無効化する
-        # https://github.com/actions/setup-node/issues/516#issuecomment-1153635273
-        # cache: yarn
+        cache: yarn
     # Enable tmate debugging of manually-triggered workflows if the input option was provided
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3


### PR DESCRIPTION
This reverts commit 7f1c350411098042654988e5ae39dfeea2c07ab8.
